### PR TITLE
Expose check_pass for the use of various auth plugins and support bcrypt

### DIFF
--- a/src/emqx_passwd.erl
+++ b/src/emqx_passwd.erl
@@ -14,11 +14,35 @@
 
 -module(emqx_passwd).
 
--export([hash/2]).
+-export([hash/2, check_pass/2]).
 
 -type(hash_type() :: plain | md5 | sha | sha256 | pbkdf2 | bcrypt).
 
 -export_type([hash_type/0]).
+
+-spec(check_pass(binary() | tuple(), binary() | tuple()) -> binary()).
+check_pass({PassHash, Password}, bcrypt) ->
+	case binary:part(PassHash, {0,29}) of		
+		{error, Error}->
+            error_logger:error_msg("bcrypt hash error:~p", [Error]),
+            <<>>;
+		Salt ->
+			check_pass(PassHash, emqx_passwd:hash(bcrypt, {Salt, Password}))
+    end;
+check_pass({PassHash, Password}, HashType) ->
+    check_pass(PassHash, emqx_passwd:hash(HashType, Password));
+check_pass({PassHash, Salt, Password}, {pbkdf2, Macfun, Iterations, Dklen}) ->
+    check_pass(PassHash, emqx_passwd:hash(pbkdf2, {Salt, Password, Macfun, Iterations, Dklen}));
+check_pass({PassHash, Salt, Password}, {salt, bcrypt}) ->
+    check_pass(PassHash, emqx_passwd:hash(bcrypt, {Salt, Password}));
+check_pass({PassHash, Salt, Password}, {bcrypt, salt}) ->
+    check_pass(PassHash, emqx_passwd:hash(bcrypt, {Salt, Password}));
+check_pass({PassHash, Salt, Password}, {salt, HashType}) ->
+    check_pass(PassHash, emqx_passwd:hash(HashType, <<Salt/binary, Password/binary>>));
+check_pass({PassHash, Salt, Password}, {HashType, salt}) ->
+    check_pass(PassHash, emqx_passwd:hash(HashType, <<Password/binary, Salt/binary>>));
+check_pass(PassHash, PassHash) -> ok;
+check_pass(_Hash1, _Hash2)     -> {error, password_error}.
 
 -spec(hash(hash_type(), binary() | tuple()) -> binary()).
 hash(plain, Password)  ->


### PR DESCRIPTION
There are mainly 2 changes for this commit:
1.  Allow hash type to be bcrypt in addition to {salt, bcrypt}. If bcrypt is specified, salt will be extracted from the password hash.
2. Refactor check_pass. This function duplicates in many auth plugins such as emqx_auth_mysql, emqx_auth_redis etc. Move check_pass into emqx_passwd and let auth plugins invoke this common function(this change reside in the auth plugins' repository) to remove duplicates.