### PR TITLE
Expose check_pass for the use of various auth plugins and support bcrypt

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ PROJECT_VERSION = 0.1
 DEPS = pbkdf2 bcrypt
 
 dep_pbkdf2 = git https://github.com/emqx/erlang-pbkdf2 2.0.2
-dep_bcrypt = git https://github.com/emqx/erlang-bcrypt 0.5.2
+dep_bcrypt = git https://github.com/emqx/erlang-bcrypt
 
 LOCAL_DEPS = ssl
 

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ PROJECT_VERSION = 0.1
 DEPS = pbkdf2 bcrypt
 
 dep_pbkdf2 = git https://github.com/emqx/erlang-pbkdf2 2.0.2
-dep_bcrypt = git https://github.com/emqx/erlang-bcrypt
+dep_bcrypt = git https://github.com/emqx/erlang-bcrypt 0.5.3
 
 LOCAL_DEPS = ssl
 

--- a/src/emqx_passwd.erl
+++ b/src/emqx_passwd.erl
@@ -22,8 +22,8 @@
 
 -spec(check_pass(binary() | tuple(), binary() | tuple()) -> binary()).
 check_pass({PassHash, Password}, bcrypt) ->
-    try binary:part(PassHash, {0,29}) of	
-        {error, Error}->
+    try binary:part(PassHash, {0, 29}) of	
+        {error, Error} ->
             error_logger:error_msg("bcrypt hash error:~p", [Error]),
             <<>>;
         Salt ->

--- a/src/emqx_passwd.erl
+++ b/src/emqx_passwd.erl
@@ -22,12 +22,15 @@
 
 -spec(check_pass(binary() | tuple(), binary() | tuple()) -> binary()).
 check_pass({PassHash, Password}, bcrypt) ->
-	case binary:part(PassHash, {0,29}) of		
-		{error, Error}->
+    try binary:part(PassHash, {0,29}) of	
+        {error, Error}->
             error_logger:error_msg("bcrypt hash error:~p", [Error]),
             <<>>;
-		Salt ->
-			check_pass(PassHash, emqx_passwd:hash(bcrypt, {Salt, Password}))
+        Salt ->
+            check_pass(PassHash, emqx_passwd:hash(bcrypt, {Salt, Password}))
+    catch
+        error:badarg -> error_logger:error_msg("bcrypt hash error:incorrect hash"),
+        <<>>
     end;
 check_pass({PassHash, Password}, HashType) ->
     check_pass(PassHash, emqx_passwd:hash(HashType, Password));

--- a/src/emqx_passwd.erl
+++ b/src/emqx_passwd.erl
@@ -14,11 +14,35 @@
 
 -module(emqx_passwd).
 
--export([hash/2]).
+-export([hash/2, check_pass/2]).
 
 -type(hash_type() :: plain | md5 | sha | sha256 | pbkdf2 | bcrypt).
 
 -export_type([hash_type/0]).
+
+-spec(check_pass(binary() | tuple(), binary() | tuple()) -> binary()).
+check_pass({PassHash, Password}, bcrypt) ->
+	case binary:part(PassHash, {0,29}) of		
+		{error, Error}->
+            error_logger:error_msg("bcrypt hash error:~p", [Error]),
+            <<>>;
+		Salt ->
+			check_pass(PassHash, emqx_passwd:hash(bcrypt, {Salt, Password}))
+    end;
+check_pass({PassHash, Password}, HashType) ->
+    check_pass(PassHash, emqx_passwd:hash(HashType, Password));
+check_pass({PassHash, Salt, Password}, {pbkdf2, Macfun, Iterations, Dklen}) ->
+    check_pass(PassHash, emqx_passwd:hash(pbkdf2, {Salt, Password, Macfun, Iterations, Dklen}));
+check_pass({PassHash, Salt, Password}, {salt, bcrypt}) ->
+    check_pass(PassHash, emqx_passwd:hash(bcrypt, {Salt, Password}));
+check_pass({PassHash, Salt, Password}, {bcrypt, salt}) ->
+    check_pass(PassHash, emqx_passwd:hash(bcrypt, {Salt, Password}));
+check_pass({PassHash, Salt, Password}, {salt, HashType}) ->
+    check_pass(PassHash, emqx_passwd:hash(HashType, <<Salt/binary, Password/binary>>));
+check_pass({PassHash, Salt, Password}, {HashType, salt}) ->
+    check_pass(PassHash, emqx_passwd:hash(HashType, <<Password/binary, Salt/binary>>));
+check_pass(PassHash, PassHash) -> ok;
+check_pass(_Hash1, _Hash2)     -> {error, password_error}.
 
 -spec(hash(hash_type(), binary() | tuple()) -> binary()).
 hash(plain, Password)  ->


### PR DESCRIPTION
This is a clone pr from https://github.com/emqx/emqx-passwd/pull/2 to base on emqx30 branch.
There are mainly 2 changes for this commit:

Allow hash type to be bcrypt in addition to {salt, bcrypt}. If bcrypt is specified, salt will be extracted from the password hash.
Refactor check_pass. This function duplicates in many auth plugins such as emqx_auth_mysql, emqx_auth_redis etc. Move check_pass into emqx_passwd and let auth plugins invoke this common function(this change reside in the auth plugins' repository) to remove duplicates.